### PR TITLE
Enable to store the plugin's config in the config root

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,26 @@ This plugin reads connection properties from the `application.conf` and gives yo
 
 #### Add this to your conf/application.conf
 
-The plugin will look for the mongo config under a root of the `Application#mode`. If no configuration is found for the current application mode then the fallback is `Mode.Dev`
+The plugin will look for the mongo config under:
+ - the config root, then if not found
+ - the root of the `Application#mode`, then if not found
+ - the root of the `Application#Dev`
 
 ```
-Dev {
-    mongodb {
-        uri = "mongodb://username:password@localhost:27017/your_db_name"
-        channels = 5
-        failoverStrategy = {
-            initialDelayMsecs = 100
-            retries = 10
-            delay = {
-                function = fibonacci
-                factor = 1
-            }
+
+mongodb {
+    uri = "mongodb://username:password@localhost:27017/your_db_name"
+    channels = 5
+    failoverStrategy = {
+        initialDelayMsecs = 100
+        retries = 10
+        delay = {
+            function = fibonacci
+            factor = 1
         }
     }
 }
+
 ```
 
 ### Installing

--- a/src/main/scala/play/modules/reactivemongo/ReactiveMongoPlugin.scala
+++ b/src/main/scala/play/modules/reactivemongo/ReactiveMongoPlugin.scala
@@ -63,9 +63,10 @@ object ReactiveMongoPlugin {
 
   private [reactivemongo] def parseConf(app: Application): MongoConnector = {
 
-    val mongoConfig = app.configuration.getConfig(s"${app.mode}.mongodb")
+    val mongoConfig = app.configuration.getConfig("mongodb")
+      .getOrElse(app.configuration.getConfig(s"${app.mode}.mongodb")
       .getOrElse(app.configuration.getConfig(s"${Mode.Dev}.mongodb")
-      .getOrElse(throw new Exception("The application does not contain required mongodb configuration")))
+      .getOrElse(throw new Exception("The application does not contain required mongodb configuration"))))
 
     mongoConfig.getString("uri") match {
       case Some(uri) => {


### PR DESCRIPTION
Open sourced microservices don't use the run.mode in their configs anymore